### PR TITLE
fix: get back to MyISAM engine for database schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ NOTE 2: You can set `KARUTA_REPORT_FOLDER` environnement variable to customize t
 **The database should be created first with required grants for the server where is deployed Karuta. For that you can use the sql script etc/database/karuta-account.sql as example.**
 
 NB: The database should be tuned with this conf:
-  
+
   - create custom file for mariadb 10.5 on debian 11 like `/etc/mysql/mariadb.conf.d/51-custom.cnf`
   - edit and add the content
 
@@ -181,3 +181,5 @@ git pull #(maybe git stash && git pull && git stash --apply)
   - `mysql -h${sql.server.host} -u ${user} -p ${password} ${database} -e "DROP TABLE vector_table;"`
   - `mysql -h${sql.server.host} -u ${user} -p ${password} ${database} < etc/database/report-helper.sql`
 
+- When migrating from kapc 1.3, apply also such change on database:
+  - make dump of database, apply `sed -e 's/^) ENGINE=MyISAM/) ENGINE=InnoDB/'` on file and import dump - warning fonctions (routines) should be dumped too, or you will need to import `etc/database/karuta-backend-func.sql`

--- a/etc/database/karuta-backend.sql
+++ b/etc/database/karuta-backend.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS `log_table` (
   `log_out_body` text COLLATE utf8_unicode_ci,
   `log_code` int(12) NOT NULL,
   PRIMARY KEY (`log_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --
 -- Contenu de la table `log`
@@ -62,7 +62,7 @@ CREATE TABLE IF NOT EXISTS `node` (
   KEY `res_node_uuid` (`res_node_uuid`),
   KEY `res_res_node_uuid` (`res_res_node_uuid`),
   KEY `res_context_node_uuid` (`res_context_node_uuid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --
 -- Contenu de la table `node`
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS `portfolio` (
   `active` int(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`portfolio_id`),
   KEY `root_node_uuid` (`root_node_uuid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --
 -- Contenu de la table `portfolio`
@@ -107,7 +107,7 @@ CREATE TABLE IF NOT EXISTS `resource_table` (
   `modif_date` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`node_uuid`),
   FULLTEXT KEY `content` (`content`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --
 -- Contenu de la table `resource`
@@ -134,7 +134,7 @@ CREATE TABLE IF NOT EXISTS `credential` (
   `other` varchar(255) DEFAULT '' NOT NULL,
   PRIMARY KEY (`userid`),
   UNIQUE KEY `login` (`login`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- credential_substitution
 CREATE TABLE IF NOT EXISTS `credential_substitution` (
@@ -142,21 +142,21 @@ CREATE TABLE IF NOT EXISTS `credential_substitution` (
   `id` bigint(20) NOT NULL,
   `type` enum('USER','GROUP') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'USER',
   PRIMARY KEY (`userid`,`id`,`type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- credential_group
 CREATE TABLE IF NOT EXISTS `credential_group` (
   `cg` bigint(20) NOT NULL AUTO_INCREMENT,
   `label` varchar(255) COLLATE utf8_unicode_ci NOT NULL UNIQUE,
   PRIMARY KEY (`cg`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- credential_group_members
 CREATE TABLE IF NOT EXISTS `credential_group_members` (
   `cg` bigint(20) NOT NULL,
   `userid` bigint(20) NOT NULL,
   PRIMARY KEY (`cg`,`userid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- Portfolio group
 CREATE TABLE IF NOT EXISTS `portfolio_group` (
@@ -165,7 +165,7 @@ CREATE TABLE IF NOT EXISTS `portfolio_group` (
   `type` enum('GROUP','PORTFOLIO') COLLATE utf8_unicode_ci NOT NULL,
   `pg_parent` bigint(20),
   PRIMARY KEY (`pg`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 --
 
 -- portfolio_group_members
@@ -173,7 +173,7 @@ CREATE TABLE IF NOT EXISTS `portfolio_group_members` (
   `pg` bigint(20) NOT NULL,
   `portfolio_id` binary(16) NOT NULL DEFAULT '\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',
   PRIMARY KEY (`pg`,`portfolio_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- password = UNHEX(SHA1('password'))
 
@@ -186,7 +186,7 @@ CREATE TABLE IF NOT EXISTS `group_right_info` (
   `change_rights` tinyint(1) NOT NULL DEFAULT '0',
   `portfolio_id` binary(16) DEFAULT NULL,
   PRIMARY KEY (`grid`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- Droit et groupe
 CREATE TABLE IF NOT EXISTS `group_rights` (
@@ -201,7 +201,7 @@ CREATE TABLE IF NOT EXISTS `group_rights` (
   `rules_id` text COLLATE utf8_unicode_ci,
   `notify_roles` text COLLATE utf8_unicode_ci,
   PRIMARY KEY (`grid`,`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- Group Info
 CREATE TABLE IF NOT EXISTS `group_info` (
@@ -210,21 +210,21 @@ CREATE TABLE IF NOT EXISTS `group_info` (
   `owner` bigint(20) NOT NULL,
   `label` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'Nouveau groupe',
   PRIMARY KEY (`gid`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- Group with users
 CREATE TABLE IF NOT EXISTS `group_user` (
   `gid` bigint(20) NOT NULL,
   `userid` bigint(20) NOT NULL,
   PRIMARY KEY (`gid`,`userid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- Group with groups
 CREATE TABLE IF NOT EXISTS `group_group` (
   `gid` bigint(20) NOT NULL,
   `child_gid` bigint(20) NOT NULL,
   PRIMARY KEY (`gid`,`child_gid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 -- Annotation
 CREATE TABLE IF NOT EXISTS `annotation` (
@@ -235,7 +235,7 @@ CREATE TABLE IF NOT EXISTS `annotation` (
   `a_user` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `wad_identifier` varchar(45) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`nodeid`,`rank`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 --
 
 
@@ -251,7 +251,7 @@ CREATE TABLE IF NOT EXISTS `data_table` (
   `c_date` bigint(20) DEFAULT NULL,
   `data` blob,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --
 

--- a/etc/database/report-helper.sql
+++ b/etc/database/report-helper.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS `vector_table` (
   `a9` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT "",
   `a10` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT "",
   PRIMARY KEY(lineid)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --
 -- Contenu de la table `log`
@@ -29,11 +29,11 @@ CREATE TABLE IF NOT EXISTS `vector_usergroup` (
   `userid` bigint(20) NOT NULL,
   `lineid` bigint(20) NOT NULL,
   PRIMARY KEY(groupid, userid, lineid)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `vector_rights` (
   `groupid` bigint(20) NOT NULL,
   `RD` tinyint(1) NOT NULL DEFAULT '1',
   `WR` tinyint(1) NOT NULL DEFAULT '0',
   `DL` tinyint(1) NOT NULL DEFAULT '0'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;


### PR DESCRIPTION
InnoDB cause database lock problems that aren't managed well by the karuta-backend.